### PR TITLE
feat: expand/collapse all options

### DIFF
--- a/packages/userscript/source/ui/EngineSettingsUi.ts
+++ b/packages/userscript/source/ui/EngineSettingsUi.ts
@@ -44,6 +44,30 @@ export class EngineSettingsUi extends SettingsSectionUi<EngineSettings> {
       }
     });
 
+    const list = $("<ul/>", {
+      id: `items-list-${toggleName}`,
+      css: { display: "none", paddingLeft: "0px", paddingTop: "4px" },
+    });
+
+    const itemsElement = this._getItemsToggle(toggleName);
+    element.append(itemsElement);
+
+    itemsElement.on("click", () => {
+      list.toggle();
+
+      this._itemsExpanded = !this._itemsExpanded;
+
+      itemsElement.text(this._itemsExpanded ? "-" : "+");
+      itemsElement.prop(
+        "title",
+        this._itemsExpanded ? this._host.i18n("ui.itemsHide") : this._host.i18n("ui.itemsShow")
+      );
+    });
+
+    label.on("click", () => itemsElement.trigger("click"));
+
+    element.append(list);
+
     this.element = element;
   }
 

--- a/packages/userscript/source/ui/UserInterface.ts
+++ b/packages/userscript/source/ui/UserInterface.ts
@@ -59,18 +59,21 @@ export class UserInterface {
 
     optionsElement.append(optionsTitleElement);
 
+    const engineListElement = this._engineUi.element.children("#items-list-engine");
+
+    engineListElement.append(this._bonfireUi.element);
+    engineListElement.append(this._distributeUi.element);
+    engineListElement.append(this._unlockUi.element);
+    engineListElement.append(this._craftUi.element);
+    engineListElement.append(this._tradingUi.element);
+    engineListElement.append(this._religionUi.element);
+    engineListElement.append(this._spaceUi.element);
+    engineListElement.append(this._timeUi.element);
+    engineListElement.append(this._timeCtrlUi.element);
+    engineListElement.append(this._optionsUi.element);
+    engineListElement.append(this._filterUi.element);
+
     optionsListElement.append(this._engineUi.element);
-    optionsListElement.append(this._bonfireUi.element);
-    optionsListElement.append(this._distributeUi.element);
-    optionsListElement.append(this._unlockUi.element);
-    optionsListElement.append(this._craftUi.element);
-    optionsListElement.append(this._tradingUi.element);
-    optionsListElement.append(this._religionUi.element);
-    optionsListElement.append(this._spaceUi.element);
-    optionsListElement.append(this._timeUi.element);
-    optionsListElement.append(this._timeCtrlUi.element);
-    optionsListElement.append(this._optionsUi.element);
-    optionsListElement.append(this._filterUi.element);
 
     // Set up the "show activity summary" area.
     const activityBox = $("<div/>", {


### PR DESCRIPTION
## Description
Put every other major option inside a list (#items-list-engine) under the  "Kitten Scientists" (#ks-engine) list element. Only issue is that the sidebar width shrinks when the options are collapsed (not sure what causes it).

## Related issues
Resolves #109

## Images

![image](https://user-images.githubusercontent.com/11474057/178929099-0b6b6467-8177-49ba-b8cc-79956c199b29.png)

![image](https://user-images.githubusercontent.com/11474057/178929182-8504fcb6-05b0-4d3c-9e44-4e90633caeea.png)
