### PR TITLE
feat: expand/collapse options

### DIFF
--- a/packages/userscript/source/ui/EngineSettingsUi.ts
+++ b/packages/userscript/source/ui/EngineSettingsUi.ts
@@ -44,6 +44,9 @@ export class EngineSettingsUi extends SettingsSectionUi<EngineSettings> {
       }
     });
 
+    const toggleOptionsVisiblity = this._getItemsToggle(toggleName);
+    element.append(toggleOptionsVisiblity);
+
     this.element = element;
   }
 

--- a/packages/userscript/source/ui/SettingsSectionUi.ts
+++ b/packages/userscript/source/ui/SettingsSectionUi.ts
@@ -25,6 +25,7 @@ export type SettingsSectionUiComposition = {
  */
 export abstract class SettingsSectionUi<TState> {
   protected _host: UserScript;
+  protected _mainChild: JQuery<HTMLElement> | null = null;
   protected _itemsExpanded = false;
 
   constructor(host: UserScript) {
@@ -34,6 +35,19 @@ export abstract class SettingsSectionUi<TState> {
   abstract getState(): TState;
   abstract setState(state: TState): void;
   abstract refreshUi(): void;
+
+  /**
+   * Expands the options list if true, and collapses it if false.
+   * Changes the value of _itemsExpanded even if _mainChild is not defined.
+   * @returns the value of _itemsExpanded
+   */
+  public toggleOptions(display = !this._itemsExpanded) {
+    this._itemsExpanded = display;
+    if (this._mainChild) {
+      this._mainChild.toggle(display);
+    }
+    return this._itemsExpanded;
+  }
 
   /**
    * Constructs a settings panel that is used to contain a major section of the UI.
@@ -51,6 +65,8 @@ export abstract class SettingsSectionUi<TState> {
     options: SettingsSection,
     mainChild: JQuery<HTMLElement>
   ): SettingsSectionUiComposition {
+    this._mainChild = mainChild;
+
     const panelElement = $("<li/>", { id: `ks-${id}` });
     // Add a border on the element
     panelElement.css("borderTop", "1px solid rgba(185, 185, 185, 0.2)");
@@ -83,9 +99,7 @@ export abstract class SettingsSectionUi<TState> {
     panelElement.append(itemsElement);
 
     itemsElement.on("click", () => {
-      mainChild.toggle();
-
-      this._itemsExpanded = !this._itemsExpanded;
+      this.toggleOptions();
 
       itemsElement.text(this._itemsExpanded ? "-" : "+");
       itemsElement.prop(

--- a/packages/userscript/source/ui/UserInterface.ts
+++ b/packages/userscript/source/ui/UserInterface.ts
@@ -72,6 +72,48 @@ export class UserInterface {
     optionsListElement.append(this._optionsUi.element);
     optionsListElement.append(this._filterUi.element);
 
+    // Make _engineUI's expando button hide/show the other option groups
+    // Currently accesses the button via id.
+    let optionsToggle = this._engineUi.element.children("#toggle-items-engine");
+    optionsToggle.on("click", () => {
+      let optionsVisiblity = this._engineUi.toggleOptions();
+      this._bonfireUi.element.toggle(optionsVisiblity);
+      this._spaceUi.element.toggle(optionsVisiblity);
+      this._craftUi.element.toggle(optionsVisiblity);
+      this._unlockUi.element.toggle(optionsVisiblity);
+      this._tradingUi.element.toggle(optionsVisiblity);
+      this._religionUi.element.toggle(optionsVisiblity);
+      this._timeUi.element.toggle(optionsVisiblity);
+      this._timeCtrlUi.element.toggle(optionsVisiblity);
+      this._distributeUi.element.toggle(optionsVisiblity);
+      this._optionsUi.element.toggle(optionsVisiblity);
+      this._filterUi.element.toggle(optionsVisiblity);
+
+      optionsToggle.text(optionsVisiblity ? "-" : "+");
+      optionsToggle.prop(
+        "title",
+        optionsVisiblity ? this._host.i18n("ui.itemsHide") : this._host.i18n("ui.itemsShow")
+      );
+    });
+
+    // collapse all options if the Enable Kitten Scientists label is shift-clicked
+    this._engineUi.element.children("label").on("click", e => {
+      if (!e.shiftKey) {
+        return;
+      }
+      this._bonfireUi.toggleOptions(false);
+      this._spaceUi.toggleOptions(false);
+      this._craftUi.toggleOptions(false);
+      this._unlockUi.toggleOptions(false);
+      this._tradingUi.toggleOptions(false);
+      this._religionUi.toggleOptions(false);
+      this._timeUi.toggleOptions(false);
+      this._timeCtrlUi.toggleOptions(false);
+      this._distributeUi.toggleOptions(false);
+      this._optionsUi.toggleOptions(false);
+      this._filterUi.toggleOptions(false);
+    });
+
     // Set up the "show activity summary" area.
     const activityBox = $("<div/>", {
       id: "activity-box",

--- a/packages/userscript/source/ui/UserInterface.ts
+++ b/packages/userscript/source/ui/UserInterface.ts
@@ -74,9 +74,9 @@ export class UserInterface {
 
     // Make _engineUI's expando button hide/show the other option groups
     // Currently accesses the button via id.
-    let optionsToggle = this._engineUi.element.children("#toggle-items-engine");
+    const optionsToggle = this._engineUi.element.children("#toggle-items-engine");
     optionsToggle.on("click", () => {
-      let optionsVisiblity = this._engineUi.toggleOptions();
+      const optionsVisiblity = this._engineUi.toggleOptions();
       this._bonfireUi.element.toggle(optionsVisiblity);
       this._spaceUi.element.toggle(optionsVisiblity);
       this._craftUi.element.toggle(optionsVisiblity);
@@ -97,8 +97,8 @@ export class UserInterface {
     });
 
     // collapse all options if the Enable Kitten Scientists label is shift-clicked
-    this._engineUi.element.children("label").on("click", e => {
-      if (!e.shiftKey) {
+    this._engineUi.element.children("label").on("click", event => {
+      if (!event.shiftKey) {
         return;
       }
       this._bonfireUi.toggleOptions(false);


### PR DESCRIPTION
## Description
Added a public `toggleOptions()` method to `SettingsSectionUi` that behaves similar to jQuery's `.toggle()`. This is in charge of expanding/collapsing list options.

Added a +/- button via `_getItemsToggle()``beside "Enable Kitten Scientists" that shows/hides the rest of the options.

Shift-clicking "Enable Kitten Scientists" now collapses all the other options.

## Related issues
Resolves #109 

## Demo
Note: clicks on "Enable Kitten Scientists" are shift-clicks.

https://user-images.githubusercontent.com/11474057/178987223-67291ebb-8b14-4532-b2a7-e1378fc14669.mp4


