### PR TITLE
Mount the entire build output dir in the container

### DIFF
--- a/packages/kitten-game/Dockerfile
+++ b/packages/kitten-game/Dockerfile
@@ -6,6 +6,17 @@ RUN git clone https://bitbucket.org/bloodrizer/kitten-game.git && \
   cd kitten-game && \
   yarn install
 
+# The entire build output directory will be mounted inside the docker container at /kitten-game/build.
+# If the build process changes the inode of the kitten-scientists.inject.js file, then the new
+# file will be visible inside the container. In contrast, if only the single file is mounted inside
+# the container, then the mount is tied to that specific inode. Build updates that change the inode
+# will not be visible in the container.
+RUN mkdir -p /kitten-game/build
+
+# Also symlink to the build artifact from the /kitten-game directory, where inject-scientists.js
+# normally expects to find the file.
+RUN ln -s /kitten-game/build/kitten-scientists.inject.js /kitten-game/kitten-scientists.inject.js
+
 WORKDIR /kitten-game
 COPY "inject-scientists.js" "inject-scientists.js"
 RUN node inject-scientists.js

--- a/scripts/run-development-container.sh
+++ b/scripts/run-development-container.sh
@@ -16,7 +16,7 @@ echo ""
 echo "Starting new container..."
 docker run \
   --detach \
-  --mount type=bind,source="${BASEDIR}/../packages/userscript/output/kitten-scientists.inject.js",target=/kitten-game/kitten-scientists.inject.js \
+  --mount type=bind,source="${BASEDIR}/../packages/userscript/output",target=/kitten-game/build \
   --name kitten-game \
   --publish 8100:8080 kitten-game
 echo "Container started."


### PR DESCRIPTION
Mount the entire build output directory in the docker container instead of just the single build output file. If the build process changes the inode of the output file, the container mount will still be referencing the old inode and will not see the updates.